### PR TITLE
Use `find_packages` rather than listing explicitly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup, find_packages
 
 config = {
     'description': 'Raw Tiles',
@@ -17,7 +17,7 @@ config = {
         'msgpack-python',
         'boto3'
     ],
-    'packages': ['raw_tiles'],
+    'packages': find_packages(exclude=['ez_setup', 'examples', 'tests']),
     'scripts': [],
     'name': 'raw_tiles',
     'test_suite': 'tests',


### PR DESCRIPTION
I think this will find all the source files, including in sub-directories, rather than just `raw_tiles/*.py`. Hopefully this fixes downstream errors about not being able to find the `raw_tiles.index.index` module.