### PR TITLE
Separate sources and sinks

### DIFF
--- a/raw_tiles/__init__.py
+++ b/raw_tiles/__init__.py
@@ -1,0 +1,11 @@
+from collections import namedtuple
+
+
+# represents a particular source location, eg data from a postgresql table
+SourceLocation = namedtuple('SourceLocation', 'name records')
+
+# contains a name associated with data that has been formatted
+FormattedData = namedtuple('FormattedData', 'name data')
+
+# Container for a particular tile, and the formatted data within it
+RawrTile = namedtuple('RawrTile', 'tile all_formatted_data')

--- a/raw_tiles/command.py
+++ b/raw_tiles/command.py
@@ -1,7 +1,8 @@
-from raw_tiles.formatter.msgpack import Msgpack
 from raw_tiles.formatter.gzip import Gzip
-from raw_tiles.source.osm import OsmSource
+from raw_tiles.formatter.msgpack import Msgpack
+from raw_tiles.gen import RawrGenerator
 from raw_tiles.sink.local import LocalSink
+from raw_tiles.source.osm import OsmSource
 from raw_tiles.tile import Tile
 
 
@@ -59,9 +60,10 @@ if __name__ == '__main__':
 
     src = OsmSource(args.dbparams)
     fmt = Gzip(Msgpack())
-    sink = LocalSink('tiles', fmt)
+    sink = LocalSink('tiles', '.msgpack.gz')
+    rawr_gen = RawrGenerator(src, fmt, sink)
 
     for x in x_range:
         for y in y_range:
             tile = Tile(z, x, y)
-            src.write(sink, tile)
+            rawr_gen(tile)

--- a/raw_tiles/formatter/gzip.py
+++ b/raw_tiles/formatter/gzip.py
@@ -28,6 +28,3 @@ class Gzip(object):
         gz = GzipFile(None, 'wb', self.compression_level, io)
         buf = BufferedWriter(gz, buffer_size=BUFFER_SIZE)
         return self.formatter.create(buf)
-
-    def extension(self):
-        return self.formatter.extension() + ".gz"

--- a/raw_tiles/formatter/msgpack.py
+++ b/raw_tiles/formatter/msgpack.py
@@ -20,6 +20,3 @@ class File(object):
 class Msgpack(object):
     def create(self, io):
         return File(io)
-
-    def extension(self):
-        return "msgpack"

--- a/raw_tiles/gen.py
+++ b/raw_tiles/gen.py
@@ -1,0 +1,29 @@
+from cStringIO import StringIO
+from raw_tiles import FormattedData
+from raw_tiles import RawrTile
+
+
+class RawrGenerator(object):
+
+    """put the pieces of rawr tile generation pipeline together"""
+
+    def __init__(self, source, formatter, sink):
+        self.source = source
+        self.formatter = formatter
+        self.sink = sink
+
+    def __call__(self, tile):
+
+        all_fmt_data = []
+        for source_location in self.source(tile):
+            buf = StringIO()
+            writer = self.formatter.create(buf)
+            for record in source_location.records:
+                writer.write(record)
+            writer.close()
+            data = buf.getvalue()
+            fmt_data = FormattedData(source_location.name, data)
+            all_fmt_data.append(fmt_data)
+
+        rawr_tile = RawrTile(tile, all_fmt_data)
+        self.sink(rawr_tile)


### PR DESCRIPTION
This separates some of the pieces a little bit more to how I expect they
will be used during batch generation.

* sources
  - no longer know about sinks
  - yield a seq of source locations, which have a name, and a list of
    tuples that represents the underlying data

* formatters
  - no longer know their extensions, but this was somewhat arbitrary.
    Seems like they didn't really care, and the edges can call things what
    they want anyway, so I just moved this into the sink.

* sinks
  - perform the io to write the formatted tile data out. I expect
    tilequeue will have an s3 implementation.

* generator
  - new concept that just threads the pieces together. I expect this to
    be the entry point for tilequeue.

Generators will assemble all the sources in the behavior that we'll
want, namely to iterate through all the sources and generate the
formatted data for a rawr tile grouping all at once. We could stream the
entire pipeline, but preventing writes if any querying or formatting
along the way failed seems preferable.