### PR TITLE
Update code to use a pluggable connection manager

### DIFF
--- a/raw_tiles/command.py
+++ b/raw_tiles/command.py
@@ -2,6 +2,7 @@ from raw_tiles.formatter.gzip import Gzip
 from raw_tiles.formatter.msgpack import Msgpack
 from raw_tiles.gen import RawrGenerator
 from raw_tiles.sink.local import LocalSink
+from raw_tiles.source.conn import ConnectionContextManager
 from raw_tiles.source.osm import OsmSource
 from raw_tiles.tile import Tile
 
@@ -58,7 +59,8 @@ if __name__ == '__main__':
     x_range = parse_range(z, args.x)
     y_range = parse_range(z, args.y)
 
-    src = OsmSource(args.dbparams)
+    conn_ctx = ConnectionContextManager(args.dbparams)
+    src = OsmSource(conn_ctx)
     fmt = Gzip(Msgpack())
     sink = LocalSink('tiles', '.msgpack.gz')
     rawr_gen = RawrGenerator(src, fmt, sink)

--- a/raw_tiles/source/conn.py
+++ b/raw_tiles/source/conn.py
@@ -1,0 +1,35 @@
+import psycopg2
+
+
+class OnDemandConnectionContext(object):
+
+    """open/close postgresql connection on demand"""
+
+    def __init__(self, dbparams):
+        self.dbparams = dbparams
+        self.conn = None
+
+    def __enter__(self):
+        self.conn = psycopg2.connect(self.dbparams)
+        return self.conn
+
+    def __exit__(self, type, value, traceback):
+        assert self.conn
+        self.conn.close()
+        self.conn = None
+
+
+class ConnectionContextManager(object):
+
+    """
+    postgresql connection manager
+
+    This just opens and closes a connection for every call, but provides a hook
+    to modify that behavior in the future if desired.
+    """
+
+    def __init__(self, dbparams):
+        self.dbparams = dbparams
+
+    def __call__(self):
+        return OnDemandConnectionContext(self.dbparams)


### PR DESCRIPTION
At the moment, the same behavior of opening and closing a connection on demand continues, but going through a function allows us to swap in a custom pool in the future if desired.