### PR TITLE
Install template files as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ config = {
         'msgpack-python',
         'boto3'
     ],
+    'include_package_data': True,
+    'package_data': {'raw_tiles.source': ['*.sql']},
     'packages': find_packages(exclude=['ez_setup', 'examples', 'tests']),
     'scripts': [],
     'name': 'raw_tiles',


### PR DESCRIPTION
In addition to the manifest, package_data must be specified to actually
include the templates in the installed location.