### PR TITLE
Unpack varargs for call to format.

### DIFF
--- a/raw_tiles/formatter/msgpack.py
+++ b/raw_tiles/formatter/msgpack.py
@@ -12,8 +12,10 @@ class File(object):
                      for x in args)
         self.io.write(self.packer.pack(args))
 
-    def close(self):
+    def flush(self):
         self.io.flush()
+
+    def close(self):
         self.io.close()
 
 

--- a/raw_tiles/gen.py
+++ b/raw_tiles/gen.py
@@ -19,9 +19,14 @@ class RawrGenerator(object):
             buf = StringIO()
             writer = self.formatter.create(buf)
             for record in source_location.records:
-                writer.write(record)
-            writer.close()
+                # record is a tuple here, and writer.write takes varargs, so
+                # we need to unpack the tuple.
+                writer.write(*record)
+            writer.flush()
             data = buf.getvalue()
+            # close writer after we get the buffer value, so that the writer
+            # hasn't closed the buffer yet.
+            writer.close()
             fmt_data = FormattedData(source_location.name, data)
             all_fmt_data.append(fmt_data)
 

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -1,0 +1,66 @@
+import unittest
+
+
+class MockSource(object):
+
+    def __init__(self, name, records):
+        self.name = name
+        self.records = records
+
+    def __call__(self, tile):
+        from raw_tiles import SourceLocation
+        location = SourceLocation(self.name, self.records)
+        return [location]
+
+
+class MockSink(object):
+
+    def __call__(self, tile):
+        self.tile = tile
+
+
+class GeneratorTest(unittest.TestCase):
+
+    def test_round_trip(self):
+        from raw_tiles.gen import RawrGenerator
+        from raw_tiles.formatter.msgpack import Msgpack
+        from raw_tiles.tile import Tile
+
+        source_name = 'test'
+        source_data = [(1, 'a', {'key': 'value'})]
+
+        source = MockSource(source_name, source_data)
+        formatter = Msgpack()
+        sink = MockSink()
+
+        gen = RawrGenerator(source, formatter, sink)
+
+        tile = Tile(0, 0, 0)
+        gen(tile)
+
+        # check the format (structures) of the returned data. should be using
+        # the namedtuple types at the top level of the raw_tiles module
+        from raw_tiles import RawrTile
+        from raw_tiles import FormattedData
+
+        self.assertIsInstance(sink.tile, RawrTile)
+        self.assertEquals(tile, sink.tile.tile)
+        self.assertEquals(1, len(sink.tile.all_formatted_data))
+
+        formatted_data = sink.tile.all_formatted_data[0]
+        self.assertIsInstance(formatted_data, FormattedData)
+        self.assertEquals(source_name, formatted_data.name)
+        self.assertIsInstance(formatted_data.data, (str, bytes))
+
+        # check that the packed data contains the same thing as we put in!
+        from msgpack import Unpacker
+        from io import BytesIO
+
+        unpacker = Unpacker(BytesIO(formatted_data.data))
+        unpacked_data = list(unpacker)
+        self.assertEquals(1, len(unpacked_data))
+        source_datum = source_data[0]
+        unpacked_datum = unpacked_data[0]
+        # expect that the unpacked version has been turned into a list, but
+        # is otherwise identical in contents.
+        self.assertEquals(source_datum, tuple(unpacked_datum))


### PR DESCRIPTION
It seems that the formatter was intended to take varargs, so when the row is passed to it without unpacking it results in an additional layer of nesting.

Added a test to make sure we can round-trip as expected through the `Msgpack` formatter.