### PR TITLE
Remove buffer->bytes logic from formatter

### DIFF
--- a/raw_tiles/formatter/msgpack.py
+++ b/raw_tiles/formatter/msgpack.py
@@ -8,8 +8,6 @@ class File(object):
         self.packer = Packer(use_bin_type=True)
 
     def write(self, *args):
-        args = tuple(bytes(x) if isinstance(x, buffer) else x
-                     for x in args)
         self.io.write(self.packer.pack(args))
 
     def flush(self):


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/290

The buffer -> bytes conversion is happening earlier at the source level.