### PR TITLE
Handle empty bounds for empty shapes.

### DIFF
--- a/raw_tiles/tile.py
+++ b/raw_tiles/tile.py
@@ -64,6 +64,10 @@ def shape_tile_coverage(shape, zoom, root_tile):
 
     assert root_tile.z <= zoom
 
+    # if the geometry is empty, then it covers no tiles.
+    if shape.is_empty:
+        return set()
+
     minx, miny, maxx, maxy = shape.bounds
     max_coord = 2 ** zoom
     rx = int(root_tile.x)

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -64,3 +64,12 @@ class TileTest(unittest.TestCase):
             Tile(16, 32768, 32768),
         ])
         self.assertEquals(expected, cov)
+
+    def test_coverage_empty(self):
+        # an empty geometry should have no coverage
+        from raw_tiles.tile import Tile, shape_tile_coverage
+        from shapely.geometry.polygon import Polygon
+
+        empty = Polygon([])
+        cov = shape_tile_coverage(empty, 16, Tile(0, 0, 0))
+        self.assertEquals(set([]), cov)


### PR DESCRIPTION
Empty geometries will return an empty tuple rather than their bounds, which causes an error in `shape_tile_coverage`. However, empty geometries cannot intersect any tiles, so we can just return an empty set.