### PR TITLE
Limit intersections to polygons.

### DIFF
--- a/raw_tiles/source/land_polygons.sql
+++ b/raw_tiles/source/land_polygons.sql
@@ -1,13 +1,27 @@
 SELECT
     gid AS __id__,
-    ST_AsBinary(ST_Intersection(the_geom, {{box}})) AS __geometry__,
+    ST_AsBinary(geom) AS __geometry__,
     jsonb_build_object(
       'source', 'openstreetmapdata.com',
       'area', way_area,
       'min_zoom', mz_earth_min_zoom
     ) AS __properties__
 
-FROM land_polygons
+FROM (
+  SELECT
+    gid,
+    -- extract only polygons. we might get linestring and point fragments when
+    -- the box and geometry touch but don't overlap. we don't want these, so
+    -- want to throw them away.
+    ST_CollectionExtract(ST_Intersection(the_geom, {{box}}), 3) AS geom,
+    way_area,
+    mz_earth_min_zoom
+
+  FROM land_polygons
+
+  WHERE
+    the_geom && {{box}}
+) maybe_empty_intersections
 
 WHERE
-    the_geom && {{box}}
+  NOT ST_IsEmpty(geom)

--- a/raw_tiles/source/water_polygons.sql
+++ b/raw_tiles/source/water_polygons.sql
@@ -1,13 +1,27 @@
 SELECT
     gid AS __id__,
-    ST_AsBinary(ST_Intersection(the_geom, {{box}})) AS __geometry__,
+    ST_AsBinary(geom) AS __geometry__,
     jsonb_build_object(
       'source', 'openstreetmapdata.com',
       'area', way_area,
       'min_zoom', mz_water_min_zoom
     ) AS __properties__
 
-FROM water_polygons
+FROM (
+  SELECT
+    gid,
+    -- extract only polygons. we might get linestring and point fragments when
+    -- the box and geometry touch but don't overlap. we don't want these, so
+    -- want to throw them away.
+    ST_CollectionExtract(ST_Intersection(the_geom, {{box}}), 3) AS geom,
+    way_area,
+    mz_water_min_zoom
+
+  FROM water_polygons
+
+  WHERE
+    the_geom && {{box}}
+) maybe_empty_intersections
 
 WHERE
-    the_geom && {{box}}
+  NOT ST_IsEmpty(geom)


### PR DESCRIPTION
The intersection performed for the water and land polygon tables can produce geometry collections containing linestrings or points where the polygons touch (i.e: a zero area overlap) the bounding box.

This change makes sure that only polygonal results are returned, and a second filter ensures that the geometries are non-empty, as that might happen if a single linestring is filtered out.

Fixes https://github.com/tilezen/tilequeue/issues/307. Although we might want to add some filtering tilequeue-side as well?