### PR TITLE
Add buffered_land to RAWR sources default

### DIFF
--- a/raw_tiles/source/__init__.py
+++ b/raw_tiles/source/__init__.py
@@ -8,6 +8,7 @@ DEFAULT_SOURCES = [
     'wof',
     'water_polygons',
     'land_polygons',
+    'buffered_land',
     'ne_10m_urban_areas',
 ]
 
@@ -24,6 +25,8 @@ def parse_sources(source_names):
                 'water_polygons', bbox_expansion_factor=1.1))
         elif source_name == 'land_polygons':
             sources.append(GenericTableSource('land_polygons'))
+        elif source_name == 'buffered_land':
+            sources.append(GenericTableSource('buffered_land'))
         elif source_name == 'ne_10m_urban_areas':
             sources.append(GenericTableSource('ne_10m_urban_areas'))
         else:

--- a/raw_tiles/source/buffered_land.sql
+++ b/raw_tiles/source/buffered_land.sql
@@ -1,0 +1,26 @@
+SELECT
+    gid AS __id__,
+    ST_AsBinary(geom) AS __geometry__,
+    jsonb_build_object(
+      'source', 'tilezen.org',
+      'min_zoom', scalerank
+    ) AS __properties__
+
+FROM (
+  SELECT
+    gid,
+    -- extract only polygons. we might get linestring and point fragments when
+    -- the box and geometry touch but don't overlap. we don't want these, so
+    -- want to throw them away.
+    ST_CollectionExtract(ST_Intersection(the_geom, {{box}}), 3) AS geom,
+    scalerank
+
+  FROM buffered_land
+
+  WHERE
+    the_geom && {{box}}
+) maybe_empty_intersections
+
+WHERE
+  NOT ST_IsEmpty(the_geom)
+  

--- a/raw_tiles/source/buffered_land.sql
+++ b/raw_tiles/source/buffered_land.sql
@@ -3,7 +3,9 @@ SELECT
     ST_AsBinary(geom) AS __geometry__,
     jsonb_build_object(
       'source', 'tilezen.org',
-      'min_zoom', scalerank
+      'min_zoom', scalerank,
+      'kind', 'maritime',
+      'maritime_boundary', TRUE
     ) AS __properties__
 
 FROM (


### PR DESCRIPTION
Fixes https://github.com/tilezen/vector-datasource/issues/1482 for RAWR tile builds by adding missing `buffered_land` table to RAWR sources table list.