### PR TITLE
Adjust WOF source name

### DIFF
--- a/raw_tiles/source/wof_neighbourhood.sql
+++ b/raw_tiles/source/wof_neighbourhood.sql
@@ -5,7 +5,7 @@ SELECT
     COALESCE(to_jsonb(l10n_name), '{}'::jsonb) ||
     jsonb_build_object(
       'name', name,
-      'source', 'whosonfirst.mapzen.com',
+      'source', 'whosonfirst.org',
       'mz_n_photos', n_photos,
       'area', area,
       'is_landuse_aoi', is_landuse_aoi,


### PR DESCRIPTION
Related to https://github.com/tilezen/vector-datasource/pull/1489#issuecomment-382181000

Switch the WOF source text to `whosonfirst.org` instead of `whosonfirst.mapzen.com`.