### PR TITLE
Include wikidata on OSM features

### DIFF
--- a/raw_tiles/source/__init__.py
+++ b/raw_tiles/source/__init__.py
@@ -11,6 +11,7 @@ DEFAULT_SOURCES = [
     'buffered_land',
     'ne_10m_urban_areas',
     'admin_areas',
+    'wikidata',
 ]
 
 
@@ -32,6 +33,8 @@ def parse_sources(source_names):
             sources.append(GenericTableSource('ne_10m_urban_areas'))
         elif source_name == 'admin_areas':
             sources.append(GenericTableSource('admin_areas'))
+        elif source_name == 'wikidata':
+            sources.append(GenericTableSource('wikidata'))
         else:
             raise ValueError('No known source with name %r' % (source_name,))
 

--- a/raw_tiles/source/wikidata.sql
+++ b/raw_tiles/source/wikidata.sql
@@ -1,0 +1,23 @@
+SELECT
+  w.id AS id,
+  hstore_to_json(w.tags) AS properties
+FROM wikidata w
+JOIN
+  (
+    SELECT DISTINCT tags->'wikidata' AS wikidata
+    FROM planet_osm_point
+    WHERE way && {{box}} AND tags ? 'wikidata'
+
+    UNION
+
+    SELECT DISTINCT tags->'wikidata' AS wikidata
+    FROM planet_osm_line
+    WHERE way && {{box}} AND tags ? 'wikidata'
+
+    UNION
+
+    SELECT DISTINCT tags->'wikidata' AS wikidata
+    FROM planet_osm_polygon
+    WHERE way && {{box}} AND tags ? 'wikidata'
+  ) x
+ON w.id = x.wikidata;


### PR DESCRIPTION
Adds a new "table" for wikidata, containing the subset corresponding to the OSM features in the RAWR tile which have a `wikidata` tag.

Connects to tilezen/vector-datasource#1873.