### PR TITLE
Include WOF wikidata ID in the RAWR tile.

### DIFF
--- a/raw_tiles/source/wof_neighbourhood.sql
+++ b/raw_tiles/source/wof_neighbourhood.sql
@@ -10,6 +10,7 @@ SELECT
       'area', area,
       'is_landuse_aoi', is_landuse_aoi,
       'placetype', wof_np.placetype_string,
+      'wikidata', wikidata,
       'min_zoom', min_zoom,
       'max_zoom', max_zoom
     ) AS __properties__


### PR DESCRIPTION
Although we added queries and data for WOF Wikidata IDs in tilezen/vector-datasource#1871, the data wasn't being queried into the RAWR tiles, and therefore didn't make it out.

Connects to tilezen/vector-datasource#858.
