### PR TITLE
Add disputed admin capitals from Natural Earth

### DIFF
--- a/raw_tiles/source/wikidata.sql
+++ b/raw_tiles/source/wikidata.sql
@@ -26,8 +26,8 @@ LEFT JOIN (
   SELECT wikidataid, hstore(array_agg(key), array_agg(value)) AS tags
   FROM (
     SELECT * FROM (
-      SELECT wikidataid, (each(hstore(pp))).key, (each(hstore(pp))).value
-      FROM ne_10m_populated_places pp
+      SELECT wikidataid, (each(hstore(ne_pp))).key, (each(hstore(ne_pp))).value
+      FROM ne_10m_populated_places ne_pp
     ) x WHERE KEY LIKE 'fclass_%' AND VALUE IS NOT NULL
   ) y GROUP BY wikidataid
 ) p ON p.wikidataid = x.wikidata;

--- a/raw_tiles/source/wikidata.sql
+++ b/raw_tiles/source/wikidata.sql
@@ -1,23 +1,33 @@
+WITH wikidata_ids AS (
+  SELECT DISTINCT tags->'wikidata' AS wikidata
+  FROM planet_osm_point
+  WHERE way && {{box}} AND tags ? 'wikidata'
+
+  UNION
+
+  SELECT DISTINCT tags->'wikidata' AS wikidata
+  FROM planet_osm_line
+  WHERE way && {{box}} AND tags ? 'wikidata'
+
+  UNION
+
+  SELECT DISTINCT tags->'wikidata' AS wikidata
+  FROM planet_osm_polygon
+  WHERE way && {{box}} AND tags ? 'wikidata'
+)
 SELECT
-  w.id AS id,
-  hstore_to_json(w.tags) AS properties
-FROM wikidata w
-JOIN
-  (
-    SELECT DISTINCT tags->'wikidata' AS wikidata
-    FROM planet_osm_point
-    WHERE way && {{box}} AND tags ? 'wikidata'
-
-    UNION
-
-    SELECT DISTINCT tags->'wikidata' AS wikidata
-    FROM planet_osm_line
-    WHERE way && {{box}} AND tags ? 'wikidata'
-
-    UNION
-
-    SELECT DISTINCT tags->'wikidata' AS wikidata
-    FROM planet_osm_polygon
-    WHERE way && {{box}} AND tags ? 'wikidata'
-  ) x
-ON w.id = x.wikidata;
+  x.wikidata AS id,
+  hstore_to_json(coalesce(w.tags, ''::hstore) || coalesce(p.tags, ''::hstore)) AS properties
+FROM wikidata_ids x
+LEFT JOIN wikidata w ON w.id = x.wikidata
+LEFT JOIN (
+  -- this grabs the wikidata, hstore(fclass_*) data, omitting null values for
+  -- fclass_*, which makes the data smaller and easier to read.
+  SELECT wikidataid, hstore(array_agg(key), array_agg(value)) AS tags
+  FROM (
+    SELECT * FROM (
+      SELECT wikidataid, (each(hstore(pp))).key, (each(hstore(pp))).value
+      FROM ne_10m_populated_places pp
+    ) x WHERE KEY LIKE 'fclass_%' AND VALUE IS NOT NULL
+  ) y GROUP BY wikidataid
+) p ON p.wikidataid = x.wikidata;


### PR DESCRIPTION
These go into the `wikidata` table, since they're keyed off the same `wikidata` ID. We use this to include the `fclass_*` for disputed places into the feature, where it can be processed into `property:xx` viewpoint overrides.

Connects to tilezen/vector-datasource#1840.
