### PR TITLE
Include featurecla(ss) as well as the POV variants in place wikidata

### DIFF
--- a/raw_tiles/source/wikidata.sql
+++ b/raw_tiles/source/wikidata.sql
@@ -28,6 +28,6 @@ LEFT JOIN (
     SELECT * FROM (
       SELECT wikidataid, (each(hstore(ne_pp))).key, (each(hstore(ne_pp))).value
       FROM ne_10m_populated_places ne_pp
-    ) x WHERE KEY LIKE 'fclass_%' AND VALUE IS NOT NULL
+    ) x WHERE (key = 'featurecla' OR key LIKE 'fclass_%') AND VALUE IS NOT NULL
   ) y GROUP BY wikidataid
 ) p ON p.wikidataid = x.wikidata;


### PR DESCRIPTION
Add `featurecla` to the wikidata for places, so it can be used to back-fill `region_capital` status when the OSM `state_capital` flag is not set.

Connects to https://github.com/tilezen/vector-datasource/pull/1906 and https://github.com/tilezen/vector-datasource/pull/1907.
